### PR TITLE
Type check

### DIFF
--- a/orm.py
+++ b/orm.py
@@ -126,7 +126,6 @@ class Manager(object):  # data mapper interface (generic repository) for models
                 raise TypeError(msg)
 
 
-
 class Model(object):  # abstract entity model with an active record interface
 
     db = None

--- a/tests.py
+++ b/tests.py
@@ -23,6 +23,12 @@ try:
     assert(post.text == 'Hello Mundo')
     post.delete()
     db.commit()
+    try:
+        invalidPost = Post(None).save(type_check=True)
+    except TypeError:
+        pass
+    else:
+        raise Exception("Failed to check type!")
     objects = Post.manager()
     objects.save(Post('Hello World'))
     assert(set(objects.get(2).public.keys()) == set(['id', 'text', 'random']))

--- a/tests.py
+++ b/tests.py
@@ -19,6 +19,13 @@ try:
     assert(post.id == 1)
     post.text = 'Hello Mundo'
     post.update()
+    try:
+        post.random = None
+        post.update(type_check=True)
+    except TypeError:
+        pass
+    else:
+        raise Exception("Failed to check type!")
     db.commit()
     assert(post.text == 'Hello Mundo')
     post.delete()


### PR DESCRIPTION
This pull implements issue #10:

Implemented column type checking and its corresponding "unit tests".

By default, `save()` and `update()` methods will throw `TypeError` when a database record is being inserted/updated with invalid column values. Type checking can be turned off by passing `type_check=False` to the `save()` or `update()` methods.
